### PR TITLE
feat(web): implement input focus key shortcut

### DIFF
--- a/apps/web/src/app/(pages)/(auth)/login/page.tsx
+++ b/apps/web/src/app/(pages)/(auth)/login/page.tsx
@@ -1,15 +1,14 @@
 'use client';
 
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { GithubIcon, GoogleIcon } from '~/app/_common/components/icons';
+import { Logo } from '~/app/_common/components/logo';
 import { Button } from '~/app/_core/components/button';
 import { Input } from '~/app/_core/components/input';
 import { Label } from '~/app/_core/components/label';
-import Link from 'next/link';
-import { Logo } from '~/app/_common/components/logo';
-import { GoogleIcon } from '~/app/_common/components/icons';
-import { GithubIcon } from '~/app/_common/components/icons';
-import { useOAuth } from '../_hooks/use-oauth';
-import { useActionState } from 'react';
 import { loginUser } from '../_actions/login-user.action';
+import { useOAuth } from '../_hooks/use-oauth';
 
 export default function LoginPage() {
   const { googleLogin, githubLogin } = useOAuth();
@@ -20,9 +19,7 @@ export default function LoginPage() {
       <form action={formAction} className='max-w-92 m-auto h-fit w-full'>
         <div className='p-6'>
           <div className='flex flex-col'>
-            <Link href='/' aria-label='home' className='w-fit'>
-              <Logo />
-            </Link>
+            <Logo />
             <h1 className='mb-1 mt-4 text-xl font-semibold'>Sign In to Bookmarket</h1>
             <p>Welcome back! Sign in to continue</p>
           </div>

--- a/apps/web/src/app/(pages)/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(pages)/(auth)/signup/page.tsx
@@ -1,15 +1,14 @@
 'use client';
 
+import Link from 'next/link';
+import { useActionState } from 'react';
+import { GithubIcon, GoogleIcon } from '~/app/_common/components/icons';
+import { Logo } from '~/app/_common/components/logo';
 import { Button } from '~/app/_core/components/button';
 import { Input } from '~/app/_core/components/input';
 import { Label } from '~/app/_core/components/label';
-import Link from 'next/link';
-import { Logo } from '~/app/_common/components/logo';
-import { GoogleIcon } from '~/app/_common/components/icons';
-import { GithubIcon } from '~/app/_common/components/icons';
-import { useOAuth } from '../_hooks/use-oauth';
-import { useActionState } from 'react';
 import { createUser } from '../_actions/create-user.action';
+import { useOAuth } from '../_hooks/use-oauth';
 
 export default function SignupPage() {
   const { googleLogin, githubLogin } = useOAuth();
@@ -20,9 +19,7 @@ export default function SignupPage() {
       <form action={formAction} className='max-w-92 m-auto h-fit w-full'>
         <div className='p-6'>
           <div className='flex flex-col'>
-            <Link href='/' aria-label='home' className='w-fit'>
-              <Logo />
-            </Link>
+            <Logo />
             <h1 className='mb-1 mt-4 text-xl font-semibold'>Jump into Bookmarket</h1>
             <p>Create an account to continue</p>
           </div>

--- a/apps/web/src/app/(pages)/(home)/home/_components/url-input.tsx
+++ b/apps/web/src/app/(pages)/(home)/home/_components/url-input.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useShortcut } from '~/app/_common/hooks/use-shortcut';
 import { Input } from '~/app/_core/components/input';
 import { cn } from '~/app/_core/utils/cn';
 
@@ -8,9 +9,20 @@ interface UrlInputProps {
 }
 
 export function UrlInput({ isValidUrl, isDisabled }: UrlInputProps) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  useShortcut('Slash', () => {
+    inputRef.current?.focus();
+  });
+
+  useShortcut('Escape', () => {
+    inputRef.current?.blur();
+  });
+
   return (
     <div className='relative'>
       <Input
+        ref={inputRef}
         name='url'
         className={cn('pl-8', !isValidUrl && 'border-red-500 focus-visible:ring-0')}
         placeholder='Paste a link to add a bookmark'

--- a/apps/web/src/app/_common/hooks/use-shortcut.tsx
+++ b/apps/web/src/app/_common/hooks/use-shortcut.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+export const useShortcut = (key: KeyCode, callback: () => void) => {
+  const handleKeyDown = React.useCallback(
+    (e: KeyboardEvent) => {
+      if (key !== e.code) return;
+      e.preventDefault();
+      callback();
+    },
+    [callback, key],
+  );
+
+  React.useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+};
+
+type KeyCode =
+  | 'MetaLeft'
+  | 'MetaRight'
+  | 'ControlLeft'
+  | 'ControlRight'
+  | 'KeyK'
+  | 'Slash'
+  | 'AltLeft'
+  | 'AltRight'
+  | 'ShiftLeft'
+  | 'ShiftRight'
+  | 'Enter'
+  | 'Escape'
+  | 'Tab'
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'Backspace'
+  | 'Delete'
+  | 'Space'
+  | 'Home'
+  | 'End'
+  | 'PageUp'
+  | 'PageDown'
+  | 'F1'
+  | 'F2'
+  | 'F3'
+  | 'F4'
+  | 'F5'
+  | 'F6'
+  | 'F7'
+  | 'F8'
+  | 'F9'
+  | 'F10'
+  | 'F11'
+  | 'F12'
+  | 'KeyA'
+  | 'KeyB'
+  | 'KeyC'
+  | 'KeyD'
+  | 'KeyE'
+  | 'KeyF'
+  | 'KeyG'
+  | 'KeyH'
+  | 'KeyI'
+  | 'KeyJ'
+  | 'KeyL'
+  | 'KeyM'
+  | 'KeyN'
+  | 'KeyO'
+  | 'KeyP'
+  | 'KeyQ'
+  | 'KeyR'
+  | 'KeyS'
+  | 'KeyT'
+  | 'KeyU'
+  | 'KeyV'
+  | 'KeyW'
+  | 'KeyX'
+  | 'KeyY'
+  | 'KeyZ'
+  | 'Digit0'
+  | 'Digit1'
+  | 'Digit2'
+  | 'Digit3'
+  | 'Digit4'
+  | 'Digit5'
+  | 'Digit6'
+  | 'Digit7'
+  | 'Digit8'
+  | 'Digit9';

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "docker compose up db -d && turbo run dev",
     "format": "prettier --write .",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "check-types": "turbo run check-types"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support to the URL input field: press "Slash" to focus and "Escape" to unfocus.
  * Introduced a new keyboard shortcut hook for handling custom key events.

* **Chores**
  * Updated the development script to automatically start the database service when running the development server.

* **Style**
  * The logo on the login and signup pages is now displayed without a link to the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->